### PR TITLE
chore: update .env.example with Vite env vars for CHESS

### DIFF
--- a/src/services/mcqService.ts
+++ b/src/services/mcqService.ts
@@ -1,0 +1,40 @@
+// src/services/mcqService.ts
+import supabase from './supabaseClient';
+import type { MCQQuestion } from '../types';
+
+export async function getRandomMCQ(params: {
+  personaKey: string;
+  orgId: string | null;
+  studentId: string;
+  difficulty?: 'easy' | 'medium' | 'hard';
+}): Promise<MCQQuestion | null> {
+  const diff = params.difficulty ?? 'easy';
+
+  const { data, error } = await supabase
+    .from('mc_questions')
+    .select('*')
+    .eq('persona_key', params.personaKey)
+    .eq('difficulty', diff)
+    .limit(20);
+
+  if (error) throw error;
+  if (!data?.length) return null;
+
+  const orgPreferred = data.filter((q: any) => q.org_id && q.org_id === params.orgId);
+  const pool = orgPreferred.length ? orgPreferred : data;
+
+  return pool[Math.floor(Math.random() * pool.length)] as MCQQuestion;
+}
+
+export async function recordMCQAnswer(params: {
+  mcqId: string;
+  studentId: string;
+  isCorrect: boolean;
+}) {
+  const { error } = await supabase.from('mcq_answers').insert({
+    mcq_id: params.mcqId,
+    user_id: params.studentId, // RLS requires this to equal auth.uid()
+    is_correct: params.isCorrect,
+  });
+  if (error) throw error;
+}


### PR DESCRIPTION
Adds VITE_SUPABASE_URL/KEY, VITE_MAPBOX_TOKEN_PK/STYLE, VITE_PINECONE_*, VITE_DEBUG. Google keys remain server-side only.